### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/fat_secret/connection.rb
+++ b/lib/fat_secret/connection.rb
@@ -57,7 +57,7 @@ module FatSecret
 
       def signature_value(base_string, access_secret = '')
         digest = OpenSSL::HMAC.digest(
-          OpenSSL::Digest::Digest.new('sha1'),
+          OpenSSL::Digest.new('sha1'),
           "#{FatSecret.configuration.shared_secret}&#{access_secret}",
           base_string
         )


### PR DESCRIPTION
The use of OpenSSL::Digest::Digest has been deprecated (https://github.com/ruby/ruby/pull/446). This PR updates the only reference in the project to use the new form.
