### PR TITLE
Fix undefined map error when zero foods are returned from search

### DIFF
--- a/lib/fat_secret/food.rb
+++ b/lib/fat_secret/food.rb
@@ -20,8 +20,14 @@ module FatSecret
           'foods.search', default_search_options.
           merge({ search_expression: search_expression }).merge(options)
         )
+
+        food_results = {}
+        unless results['foods']['food'].nil?
+          food_results = results['foods']['food'].map { |f| new(f) }
+        end
+
         ResultsProxy.new(
-          results['foods']['food'].map { |f| new(f) },
+          food_results,
           results['foods']['max_results'],
           results['foods']['page_number'],
           results['foods']['total_results']

--- a/spec/lib/fat_secret/food_spec.rb
+++ b/spec/lib/fat_secret/food_spec.rb
@@ -30,6 +30,26 @@ describe FatSecret::Food do
     it 'should have a page number' do
       subject.page_number.should eq(0)
     end
+
+    context 'when there are no results', :no_results do
+      subject do
+        VCR.use_cassette('search_for_non_existant_food', match_requests_on: [ :host ], allow_playback_repeats: true) do
+          FatSecret::Food.search('asdf')
+        end
+      end
+
+      it 'should have a result count of zero' do
+        subject.total_results.should eql(0)
+      end
+
+      it 'should have no foods' do
+        subject.should be_empty
+      end
+
+      it 'should be an array' do
+        subject.should be_a(Array)
+      end
+    end
   end
 
   describe '.get' do

--- a/spec/vcr_cassettes/search_for_non_existant_food.yml
+++ b/spec/vcr_cassettes/search_for_non_existant_food.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    # uri: http://platform.fatsecret.com/rest/server.api?format=json&max_results=50&method=foods.search&oauth_consumer_key=7ebedda1451640ecbd8db41ea22d1351&oauth_nonce=1234&oauth_signature=YEHblI2X9JWOhRgWwWDvKw%2BhoPw%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1349948152&oauth_version=1.0&page_number=0&search_expression=asdf
+    uri: http://platform.fatsecret.com/rest/server.api?format=json&max_results=50&method=foods.search&oauth_consumer_key=abcd&oauth_nonce=1234&oauth_signature=PqE6UMGxCF4FySgesdMDE8qNopI%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1325372400&oauth_version=1.0&page_number=0&search_expression=asdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - ! '*/*'
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - private
+      content-type:
+      - application/json; charset=utf-8
+      server:
+      - Microsoft-IIS/7.5
+      x-aspnet-version:
+      - 2.0.50727
+      date:
+      - Thu, 11 Oct 2012 09:35:46 GMT
+      content-length:
+      - '14621'
+    body:
+      encoding: US-ASCII
+      string: ! '{ "foods": { "food": [], "max_results": "50", "page_number": "0", "total_results": "0" }}'
+    http_version: '1.1'
+  recorded_at: Thu, 11 Oct 2012 09:35:53 GMT


### PR DESCRIPTION
For a `food.search` query that returns zero results, iterating over the
result set and attempting to create new Food objects yields the error:

`NoMethodError: undefined method 'map' for nil:NilClass`

This is fixed by only building the new Food objects if the result set
is populated with foods.
